### PR TITLE
Windows paths fix

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -35,7 +35,7 @@ function loadfiles(root, subPath, paths) {
     file = path.join(dirPath, '/', file);
     if (fs.statSync(file).isFile()) {
       if (path.extname(file) === '.js') {
-        paths[file.replace(new RegExp('^' + path.join(path.resolve(root), '/')), '').replace(/.js$/, '').toLowerCase()] = file;
+        paths[path.basename(file, '.js').toLowerCase()] = file;
       }
     } else if (fs.statSync(file).isDirectory()) {
       loadfiles(root, file, paths);

--- a/lib/ovenware.js
+++ b/lib/ovenware.js
@@ -1,4 +1,4 @@
-var path = require('path');
+var path = require('upath');
 var util = require('util');
 var methods = require('methods');
 var debug = require('debug')('ovenware');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/zedgu/ovenware",
   "dependencies": {
     "debug": "*",
-    "methods": "^1.0.1"
+    "methods": "^1.0.1",
+	"upath": "^0.1.5"
   },
   "devDependencies": {
     "body-parser": "^1.11.0",


### PR DESCRIPTION
This branch tries to fix the issue with file paths on Windows, as Windows uses backslashes instead of forward slashes. 

A proxy library, `upath`, is included to replace the original reference to the built-in module `path`. 

In `loader.js`, `path#basename` is used instead of `String#replace` to retrieve the last portion, excluding the file type suffix, of a path. 
